### PR TITLE
Store recovery codes as bcrypt'd hashes

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/abeefecabdad_implement_2fa.py
+++ b/libweasyl/libweasyl/alembic/versions/abeefecabdad_implement_2fa.py
@@ -19,7 +19,7 @@ def upgrade():
     # Create a table to store 2FA backup codes for use when the authenticator is unavailable.
     op.create_table('twofa_recovery_codes',
         sa.Column('userid', sa.Integer(), nullable=False),
-        sa.Column('recovery_code', sa.String(length=20), nullable=False),
+        sa.Column('recovery_code', sa.String(length=100), nullable=False),
         sa.PrimaryKeyConstraint('userid', 'recovery_code'),
         sa.ForeignKeyConstraint(['userid'], ['login.userid'], name='twofa_recovery_codes_userid_fkey', onupdate='CASCADE', ondelete='CASCADE'),
     )

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -400,7 +400,7 @@ Index('ind_login_login_name', login.c.login_name)
 twofa_recovery_codes = Table(
     'twofa_recovery_codes', metadata,
     Column('userid', Integer(), primary_key=True, nullable=False),
-    Column('recovery_code', String(length=20), primary_key=True, nullable=False),
+    Column('recovery_code', String(length=100), primary_key=True, nullable=False),
     default_fkey(['userid'], ['login.userid'], name='twofa_recovery_codes_userid_fkey'),
 )
 

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -161,7 +161,11 @@ def signin_2fa_auth_post_(request):
         # User is out of recovery codes, so force-deactivate 2FA
         if two_factor_auth.get_number_of_recovery_codes(tfa_userid) == 0:
             two_factor_auth.force_deactivate(tfa_userid)
-            raise WeasylError("TwoFactorAuthenticationZeroRecoveryCodesRemaining")
+            return Response(define.errorpage(
+                tfa_userid,
+                errorcode.error_messages['TwoFactorAuthenticationZeroRecoveryCodesRemaining'],
+                [["2FA Dashboard", "/control/2fa/status"], ["Return to the Home Page", "/"]]
+            ))
         raise HTTPSeeOther(location=ref)
     elif sess.additional_data['2fa_pwd_auth_attempts'] >= 5:
         # Hinder brute-forcing the 2FA token or recovery code by enforcing an upper-bound on 2FA auth attempts.

--- a/weasyl/two_factor_auth.py
+++ b/weasyl/two_factor_auth.py
@@ -271,7 +271,7 @@ def is_recovery_code_valid(userid, tfa_code, consume_recovery_code=True):
     
     # Then attempt to hash the input code versus the stored code(s).
     for recovery_code_hash in recovery_codes:
-        if bcrypt.checkpw(tfa_code, recovery_code_hash):
+        if bcrypt.checkpw(tfa_code.encode('utf-8'), recovery_code_hash):
             # We have a match! If we are deleting the code, do it now.
             if consume_recovery_code:
                 d.engine.execute("""

--- a/weasyl/two_factor_auth.py
+++ b/weasyl/two_factor_auth.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import re
 import urllib
 
+import bcrypt
 import pyotp
 from qrcodegen import QrCode
 
@@ -114,7 +115,7 @@ def activate(userid, tfa_secret, tfa_response):
     """
     totp = pyotp.TOTP(tfa_secret)
     # If the provided `tfa_response` matches the TOTP value, write the 2FA secret into `login`, activating 2FA for `userid`
-    if totp.verify(tfa_response):
+    if totp.verify(tfa_response, valid_window=1):
         d.engine.execute("""
             UPDATE login
             SET twofa_secret = %(tfa_secret)s
@@ -215,6 +216,9 @@ def store_recovery_codes(userid, recovery_codes):
         if len(code) != LENGTH_RECOVERY_CODE:
             return False
 
+    # Store the recovery codes securely by hashing them with bcrypt (as login.passhash())
+    hashed_codes = [login.passhash(code) for code in codes]
+
     # If above checks have passed, clear current recovery codes for `userid` and store new ones
     d.engine.execute("""
         BEGIN;
@@ -226,7 +230,7 @@ def store_recovery_codes(userid, recovery_codes):
         SELECT %(userid)s, unnest(%(tfa_recovery_codes)s);
 
         COMMIT;
-    """, userid=userid, tfa_recovery_codes=list(codes))
+    """, userid=userid, tfa_recovery_codes=list(hashed_codes))
 
     # Verify if the atomic transaction completed; if `code` (one of the new recovery codes) is
     #   valid at this point, the new codes were added
@@ -257,25 +261,27 @@ def is_recovery_code_valid(userid, tfa_code, consume_recovery_code=True):
     # Recovery codes must be LENGTH_RECOVERY_CODE characters; fast-fail if this is not the case
     if len(tfa_code) != LENGTH_RECOVERY_CODE:
         return False
-    # Check to see if the provided code--converting to upper-case first--is valid and consume if so
-    if consume_recovery_code:
-        tfa_rc = d.engine.scalar("""
-            DELETE FROM twofa_recovery_codes
-            WHERE userid = %(userid)s AND recovery_code = %(recovery_code)s
-            RETURNING recovery_code
-        """, userid=userid, recovery_code=tfa_code.upper())
-    else:
-        # We only want to see if the code is valid at the moment.
-        tfa_rc = d.engine.scalar("""
-            SELECT recovery_code
-            FROM twofa_recovery_codes
-            WHERE userid = %(userid)s AND recovery_code = %(recovery_code)s
-        """, userid=userid, recovery_code=tfa_code.upper())
-    # Return True if the recovery code was valid, False otherwise
-    if tfa_rc:
-        return True
-    else:
-        return False
+    
+    # First extract the bcrypt hashes.
+    recovery_codes = d.engine.execute("""
+        SELECT recovery_code
+        FROM twofa_recovery_codes
+        WHERE userid = %(userid)s AND recovery_code = %(recovery_code)s
+    """, userid=userid, recovery_code=tfa_code.upper()).fetchall()
+    
+    # Then attempt to hash the input code versus the stored code(s).
+    for recovery_code_hash in recovery_codes:
+        if bcrypt.checkpw(tfa_code, recovery_code_hash):
+            # We have a match! If we are deleting the code, do it now.
+            if consume_recovery_code:
+                d.engine.execute("""
+                    DELETE FROM twofa_recovery_codes
+                    WHERE userid = %(userid)s AND recovery_code = %(recovery_code)s
+                """, userid=userid, recovery_code=recovery_code_hash)
+            # After deletion--if applicable--return that we succeeded.
+            return True
+    # If we get here, ``tfa_code`` did not match any stored codes. Return that we failed.
+    return False
 
 
 def is_2fa_enabled(userid):


### PR DESCRIPTION
Because they really should be hashed instead of just being stored plaintext.. Uses a slightly lower work-factor for the bcrypt rounds, but it is configurable directly via a module-level variable.