### PR TITLE
Symmetrically encrypt the TOTP key prior to storing it.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,10 @@ apt-get -y install \
     liblzma-dev python-dev python-virtualenv \
     ruby-sass nodejs
 
+# Install dependencies for 'cryptography' PyPI package -- https://cryptography.io/en/latest/installation/#building-cryptography-on-linux
+apt-get -y install \
+    build-essential libssl-dev libffi-dev python-dev
+
 npm install -g gulp-cli
 
 sudo -u postgres dropdb weasyl

--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -25,3 +25,8 @@ url = postgresql+psycopg2cffi:///weasyl
 [recaptcha-lo.weasyl.com]
 public_key = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 private_key = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+[twofactorauth.totpsecret.encryption.key]
+# This key MUST be changed when in production;
+# See https://cryptography.io/en/latest/fernet/ -- Fernet.generate_key()
+secret_key = 2iY4trxnpmNLlQifnQ21pFF0nb-VlmpxRUI6W_uP1oQ=

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -19,3 +19,4 @@ pyramid==1.7.3
 WebTest==2.0.23
 pyotp==2.2.4                # For Two-Factor Authentication
 qrcodegen==1.0.0            # For Two-Factor Authentication
+cryptography==1.8.1         # For Two-Factor Authentication

--- a/libweasyl/libweasyl/alembic/versions/abeefecabdad_implement_2fa.py
+++ b/libweasyl/libweasyl/alembic/versions/abeefecabdad_implement_2fa.py
@@ -28,7 +28,7 @@ def upgrade():
     # Modify `login` to hold the 2FA code (if set) for a user account
     op.add_column(
         'login',
-        sa.Column('twofa_secret', sa.String(length=16), nullable=True, server_default=None),
+        sa.Column('twofa_secret', sa.String(length=420), nullable=True, server_default=None),
     )
 
 

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -391,7 +391,7 @@ login = Table(
         },
     }, length=20), nullable=False, server_default=''),
     Column('email', String(length=100), nullable=False, server_default=''),
-    Column('twofa_secret', String(length=16), nullable=True),
+    Column('twofa_secret', String(length=420), nullable=True),
 )
 
 Index('ind_login_login_name', login.c.login_name)


### PR DESCRIPTION
Depends on the following PyPI package: ``cryptography``

``cryptography`` requires the following OS-level packages: ``build-essential libssl-dev libffi-dev python-dev``

Requires that the ``site.config.txt`` file have a new Fernet key provided in place of the development key in ``site.config.txt.example``. Once the OS packages have been installed, then ``cryptography`` via ``pip``:

```
kyra@kitty:~/git/weasylDev/weasyl$ python
Python 2.7.9 (default, Jun 29 2016, 13:08:31)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from cryptography.fernet import Fernet
>>> Fernet.generate_key()
'GlkTNxVzaFyfv6d_Fc2BHZvR-F6QK1RNdm-9P_KzcVs='
>>>
```

Take the output of ``Fernet.generate_key()`` and stick that in the ``[twofactorauth.totpsecret.encryption.key]`` section in ``site.config.txt``.